### PR TITLE
feat(notebook): add Titanic EDA and project infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Check linting
+        run: ruff check src/ notebooks/
+
+      - name: Check formatting
+        run: ruff format --check src/ notebooks/
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short || echo "No tests found yet — skipping"

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -17,7 +17,7 @@ For global decisions applying to all Kaggle projects, see the [global DECISIONS.
 **Options considered:**
 
 | Option | Pros | Cons |
-|---|---|---|
+| --- | --- | --- |
 | Option A | ... | ... |
 | Option B | ... | ... |
 
@@ -27,4 +27,17 @@ For global decisions applying to all Kaggle projects, see the [global DECISIONS.
 
 -->
 
-## Decisions will be added here as the project progresses.
+## Global rules applied to this project
+
+All best practices from [global DECISIONS.md](../DECISIONS.md) apply here, specifically:
+
+- **ADR-016** — CI with ruff only (no SonarQube)
+- **ADR-017** — pytest on `src/` only
+- **ADR-018** — KISS and YAGNI, not SOLID
+- **ADR-019** — Reproducibility, DRY, no data leakage
+- **ADR-020** — Pipeline-centric ML approach
+- **ADR-021** — Stratified K-Fold, local CV > public leaderboard
+- **ADR-022** — Notebook hygiene (top-to-bottom, Restart & Run All)
+- **ADR-023** — Raw data immutable and gitignored
+
+No Titanic-specific decisions yet. They will be added as the project progresses.

--- a/notebooks/notebook.ipynb
+++ b/notebooks/notebook.ipynb
@@ -4,13 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Competition Name\n",
+    "# Titanic — Machine Learning from Disaster\n",
     "\n",
-    "**Goal:** Describe the competition objective here.\n",
+    "**Goal:** Predict which passengers survived the Titanic shipwreck (binary classification).\n",
     "\n",
-    "**Metric:** Describe the evaluation metric (e.g., accuracy, RMSE, AUC).\n",
+    "**Metric:** Accuracy (percentage of correct predictions).\n",
     "\n",
-    "**Kaggle link:** https://www.kaggle.com/competitions/COMPETITION_NAME"
+    "**Kaggle link:** https://www.kaggle.com/competitions/titanic"
    ]
   },
   {
@@ -30,19 +30,15 @@
     "import warnings\n",
     "from pathlib import Path\n",
     "\n",
+    "# Visualization\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
     "# Data manipulation\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "\n",
-    "# Visualization\n",
-    "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "\n",
     "# Machine Learning\n",
-    "from sklearn.model_selection import train_test_split, cross_val_score\n",
-    "from sklearn.metrics import accuracy_score, classification_report, confusion_matrix\n",
-    "from sklearn.preprocessing import LabelEncoder, StandardScaler\n",
-    "from sklearn.ensemble import RandomForestClassifier\n",
     "\n",
     "# Settings\n",
     "warnings.filterwarnings(\"ignore\")\n",
@@ -72,8 +68,8 @@
     "SUBMISSIONS_DIR = Path(\"../outputs/submissions\")\n",
     "\n",
     "# Competition settings\n",
-    "COMPETITION_NAME = \"CHANGE_ME\"  # TODO: Set your competition name\n",
-    "TARGET_COL = \"target\"           # TODO: Set your target column name\n",
+    "COMPETITION_NAME = \"titanic\"\n",
+    "TARGET_COL = \"Survived\"\n",
     "RANDOM_STATE = 42\n",
     "TEST_SIZE = 0.2"
    ]
@@ -157,23 +153,31 @@
    "outputs": [],
    "source": [
     "# Target distribution\n",
-    "# TODO: Uncomment and adapt based on your target type\n",
+    "survived_counts = train_df[TARGET_COL].value_counts()\n",
+    "survived_pct = train_df[TARGET_COL].value_counts(normalize=True) * 100\n",
     "\n",
-    "# For classification:\n",
-    "# fig, ax = plt.subplots(figsize=(8, 5))\n",
-    "# train_df[TARGET_COL].value_counts().plot(kind=\"bar\", ax=ax)\n",
-    "# ax.set_title(f\"Target Distribution: {TARGET_COL}\")\n",
-    "# ax.set_ylabel(\"Count\")\n",
-    "# plt.tight_layout()\n",
-    "# plt.show()\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "\n",
-    "# For regression:\n",
-    "# fig, ax = plt.subplots(figsize=(8, 5))\n",
-    "# train_df[TARGET_COL].hist(bins=50, ax=ax)\n",
-    "# ax.set_title(f\"Target Distribution: {TARGET_COL}\")\n",
-    "# ax.set_xlabel(TARGET_COL)\n",
-    "# plt.tight_layout()\n",
-    "# plt.show()"
+    "# Count plot\n",
+    "survived_counts.plot(kind=\"bar\", ax=axes[0], color=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "axes[0].set_title(f\"Target Distribution: {TARGET_COL}\")\n",
+    "axes[0].set_ylabel(\"Count\")\n",
+    "axes[0].set_xticklabels([\"Did not survive (0)\", \"Survived (1)\"], rotation=0)\n",
+    "\n",
+    "# Percentage pie chart\n",
+    "axes[1].pie(\n",
+    "    survived_pct,\n",
+    "    labels=[\"Did not survive (0)\", \"Survived (1)\"],\n",
+    "    autopct=\"%1.1f%%\",\n",
+    "    colors=[\"#e74c3c\", \"#2ecc71\"],\n",
+    "    startangle=90,\n",
+    ")\n",
+    "axes[1].set_title(\"Survival Rate\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Survival rate: {survived_pct.iloc[1]:.1f}% survived, {survived_pct.iloc[0]:.1f}% did not survive\")"
    ]
   },
   {
@@ -183,14 +187,243 @@
    "outputs": [],
    "source": [
     "# Correlation heatmap (numeric features only)\n",
-    "# TODO: Uncomment when ready\n",
+    "numeric_cols = train_df.select_dtypes(include=[np.number]).columns\n",
+    "fig, ax = plt.subplots(figsize=(12, 10))\n",
+    "sns.heatmap(train_df[numeric_cols].corr(), annot=True, fmt=\".2f\", cmap=\"coolwarm\", ax=ax)\n",
+    "ax.set_title(\"Correlation Matrix\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Survival Rate by Sex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Survival rate by Sex\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
     "\n",
-    "# numeric_cols = train_df.select_dtypes(include=[np.number]).columns\n",
-    "# fig, ax = plt.subplots(figsize=(12, 10))\n",
-    "# sns.heatmap(train_df[numeric_cols].corr(), annot=True, fmt=\".2f\", cmap=\"coolwarm\", ax=ax)\n",
-    "# ax.set_title(\"Correlation Matrix\")\n",
-    "# plt.tight_layout()\n",
-    "# plt.show()"
+    "sns.countplot(data=train_df, x=\"Sex\", hue=TARGET_COL, ax=axes[0], palette=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "axes[0].set_title(\"Survival Count by Sex\")\n",
+    "axes[0].legend(title=\"Survived\", labels=[\"No\", \"Yes\"])\n",
+    "\n",
+    "sex_survival = train_df.groupby(\"Sex\")[TARGET_COL].mean() * 100\n",
+    "sex_survival.plot(kind=\"bar\", ax=axes[1], color=[\"#3498db\", \"#e67e22\"])\n",
+    "axes[1].set_title(\"Survival Rate by Sex (%)\")\n",
+    "axes[1].set_ylabel(\"Survival Rate (%)\")\n",
+    "axes[1].set_xticklabels(axes[1].get_xticklabels(), rotation=0)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(sex_survival.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Survival Rate by Passenger Class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Survival rate by Pclass\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "\n",
+    "sns.countplot(data=train_df, x=\"Pclass\", hue=TARGET_COL, ax=axes[0], palette=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "axes[0].set_title(\"Survival Count by Passenger Class\")\n",
+    "axes[0].legend(title=\"Survived\", labels=[\"No\", \"Yes\"])\n",
+    "\n",
+    "pclass_survival = train_df.groupby(\"Pclass\")[TARGET_COL].mean() * 100\n",
+    "pclass_survival.plot(kind=\"bar\", ax=axes[1], color=[\"#f1c40f\", \"#3498db\", \"#e74c3c\"])\n",
+    "axes[1].set_title(\"Survival Rate by Passenger Class (%)\")\n",
+    "axes[1].set_ylabel(\"Survival Rate (%)\")\n",
+    "axes[1].set_xticklabels([\"1st\", \"2nd\", \"3rd\"], rotation=0)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(pclass_survival.to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Age Distribution by Survival"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Age distribution by survival status\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 5))\n",
+    "\n",
+    "# Overlapping histograms\n",
+    "for survived, color, label in [(0, \"#e74c3c\", \"Did not survive\"), (1, \"#2ecc71\", \"Survived\")]:\n",
+    "    subset = train_df[train_df[TARGET_COL] == survived][\"Age\"].dropna()\n",
+    "    axes[0].hist(subset, bins=30, alpha=0.6, color=color, label=label)\n",
+    "axes[0].set_title(\"Age Distribution by Survival\")\n",
+    "axes[0].set_xlabel(\"Age\")\n",
+    "axes[0].set_ylabel(\"Count\")\n",
+    "axes[0].legend()\n",
+    "\n",
+    "# Box plot\n",
+    "sns.boxplot(data=train_df, x=TARGET_COL, y=\"Age\", ax=axes[1], palette=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "axes[1].set_title(\"Age Distribution by Survival (Box Plot)\")\n",
+    "axes[1].set_xticklabels([\"Did not survive\", \"Survived\"])\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Age missing: {train_df['Age'].isnull().sum()} ({train_df['Age'].isnull().mean() * 100:.1f}%)\")\n",
+    "print(\"\\nAge stats by survival:\")\n",
+    "print(train_df.groupby(TARGET_COL)[\"Age\"].describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Embarked, Fare, and Family Size Analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Embarked, Fare, and Family analysis\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(14, 10))\n",
+    "\n",
+    "# Survival by Embarked\n",
+    "sns.countplot(data=train_df, x=\"Embarked\", hue=TARGET_COL, ax=axes[0, 0], palette=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "axes[0, 0].set_title(\"Survival by Embarkation Port\")\n",
+    "axes[0, 0].legend(title=\"Survived\", labels=[\"No\", \"Yes\"])\n",
+    "\n",
+    "embarked_survival = train_df.groupby(\"Embarked\")[TARGET_COL].mean() * 100\n",
+    "print(\"Survival rate by Embarked port:\")\n",
+    "print(embarked_survival.to_string(), \"\\n\")\n",
+    "\n",
+    "# Fare distribution\n",
+    "sns.boxplot(data=train_df, x=TARGET_COL, y=\"Fare\", ax=axes[0, 1], palette=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "axes[0, 1].set_title(\"Fare Distribution by Survival\")\n",
+    "axes[0, 1].set_xticklabels([\"Did not survive\", \"Survived\"])\n",
+    "\n",
+    "# Family size (SibSp + Parch)\n",
+    "train_df[\"FamilySize\"] = train_df[\"SibSp\"] + train_df[\"Parch\"] + 1\n",
+    "family_survival = train_df.groupby(\"FamilySize\")[TARGET_COL].mean() * 100\n",
+    "\n",
+    "family_survival.plot(kind=\"bar\", ax=axes[1, 0], color=\"#3498db\")\n",
+    "axes[1, 0].set_title(\"Survival Rate by Family Size (%)\")\n",
+    "axes[1, 0].set_xlabel(\"Family Size\")\n",
+    "axes[1, 0].set_ylabel(\"Survival Rate (%)\")\n",
+    "\n",
+    "# Alone vs with family\n",
+    "train_df[\"IsAlone\"] = (train_df[\"FamilySize\"] == 1).astype(int)\n",
+    "alone_survival = train_df.groupby(\"IsAlone\")[TARGET_COL].mean() * 100\n",
+    "alone_survival.index = [\"With family\", \"Alone\"]\n",
+    "alone_survival.plot(kind=\"bar\", ax=axes[1, 1], color=[\"#2ecc71\", \"#e74c3c\"])\n",
+    "axes[1, 1].set_title(\"Survival Rate: Alone vs With Family (%)\")\n",
+    "axes[1, 1].set_ylabel(\"Survival Rate (%)\")\n",
+    "axes[1, 1].set_xticklabels(axes[1, 1].get_xticklabels(), rotation=0)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"\\nFamily size distribution:\\n{train_df['FamilySize'].value_counts().sort_index().to_string()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cabin Feature Analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cabin feature analysis (77% missing)\n",
+    "cabin_missing_pct = train_df[\"Cabin\"].isnull().mean() * 100\n",
+    "has_cabin = train_df[\"Cabin\"].notna().astype(int)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "cabin_survival = train_df.groupby(has_cabin)[TARGET_COL].mean() * 100\n",
+    "cabin_survival.index = [\"No cabin info\", \"Has cabin info\"]\n",
+    "cabin_survival.plot(kind=\"bar\", ax=ax, color=[\"#e74c3c\", \"#2ecc71\"])\n",
+    "ax.set_title(\"Survival Rate by Cabin Info Availability (%)\")\n",
+    "ax.set_ylabel(\"Survival Rate (%)\")\n",
+    "ax.set_xticklabels(ax.get_xticklabels(), rotation=0)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Cabin missing: {train_df['Cabin'].isnull().sum()} / {len(train_df)} ({cabin_missing_pct:.1f}%)\")\n",
+    "print(f\"Survival rate with cabin info: {cabin_survival['Has cabin info']:.1f}%\")\n",
+    "print(f\"Survival rate without cabin info: {cabin_survival['No cabin info']:.1f}%\")\n",
+    "print(\"\\nNote: Cabin availability correlates with class/fare — likely a proxy for wealth.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### EDA Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EDA key findings summary\n",
+    "print(\"=\" * 60)\n",
+    "print(\"EDA KEY FINDINGS\")\n",
+    "print(\"=\" * 60)\n",
+    "print(\"\"\"\n",
+    "1. IMBALANCED TARGET: ~38% survived, ~62% did not survive.\n",
+    "\n",
+    "2. SEX is the strongest predictor:\n",
+    "   - Female survival rate ~74%, male ~19%.\n",
+    "\n",
+    "3. PCLASS matters significantly:\n",
+    "   - 1st class ~63%, 2nd ~47%, 3rd ~24%.\n",
+    "\n",
+    "4. AGE: Children had higher survival rates.\n",
+    "   - ~20% of Age values are missing — needs imputation.\n",
+    "\n",
+    "5. FARE: Survivors paid higher fares on average (correlated with Pclass).\n",
+    "\n",
+    "6. FAMILY SIZE: Solo travelers and very large families had lower survival.\n",
+    "   - Sweet spot around 2-4 family members.\n",
+    "\n",
+    "7. EMBARKED: Cherbourg (C) passengers had highest survival rate.\n",
+    "\n",
+    "8. CABIN: 77% missing. Having cabin info correlates with higher survival\n",
+    "   (proxy for wealth/class). Consider binary has_cabin feature.\n",
+    "\"\"\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Complete exploratory data analysis for the Titanic competition and set up project infrastructure (CI workflow, branch protection, labels, decision records).

## Changes

- [x] Update notebook header and configuration for Titanic competition
- [x] Implement full EDA section: target distribution, survival by sex/class/age, embarked/fare/family analysis, cabin feature, and key findings summary
- [x] Add CI workflow (`.github/workflows/ci.yml`) with ruff check, ruff format, and pytest
- [x] Add `tests/` directory for future unit tests
- [x] Update `DECISIONS.md` to reference global ADRs (016-023)

## Type of Change

- [x] New experiment / feature (`feat`)

## Results (if applicable)

N/A — EDA phase, no model metrics yet.

## Checklist

- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] `make lint` passes
- [x] Notebook outputs are stripped (nbstripout)
- [ ] Submission score logged in `outputs/submissions/log.md` (if applicable) — N/A
- [x] No raw data or model files committed

Closes #1