### PR TITLE
fix(infra): remove test fallback in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
           pip install pytest
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short || echo "No tests found yet — skipping"
+        run: pytest tests/ -v --tb=short


### PR DESCRIPTION
## Summary

Remove the silent fallback (`|| echo "No tests found yet — skipping"`) in the CI test job. Now that we have 15 real unit tests, pytest must fail the build if any test breaks.

## Changes

- [x] Remove `|| echo` fallback from pytest command in `ci.yml`

## Type of Change

- [x] Maintenance (`chore`)

## Checklist

- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] `make lint` passes
- [x] No raw data or model files committed