### PR TITLE
fix(notebook): add project root to sys.path for src/ imports

### DIFF
--- a/notebooks/notebook.ipynb
+++ b/notebooks/notebook.ipynb
@@ -27,8 +27,14 @@
    "outputs": [],
    "source": [
     "# Standard library\n",
+    "import sys\n",
     "import warnings\n",
     "from pathlib import Path\n",
+    "\n",
+    "# Add project root to Python path so we can import from src/\n",
+    "# WHY? The notebook runs from notebooks/, but src/ is at the project root.\n",
+    "# Without this, Python can't find our project modules.\n",
+    "sys.path.insert(0, str(Path(\"..\").resolve()))\n",
     "\n",
     "# Visualization\n",
     "import matplotlib.pyplot as plt\n",
@@ -854,13 +860,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError: No module named 'src'` when running the notebook. The notebook executes from `notebooks/` but `src/` is at the project root — Python needs the parent directory in its search path.

## Changes

- [x] Add `sys.path.insert(0, str(Path("..").resolve()))` in the imports cell
- [x] Document with WHY comment explaining the need

## Type of Change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] `make lint` passes
- [x] Notebook outputs are stripped (nbstripout)
- [x] Tests pass (15/15)
- [x] No raw data or model files committed