### PR TITLE
fix(notebook): fix cell types and clean up section structure

### DIFF
--- a/notebooks/notebook.ipynb
+++ b/notebooks/notebook.ipynb
@@ -514,6 +514,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Feature Engineering"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -535,7 +542,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Feature Engineering"
+    "## 7. Modeling"
    ]
   },
   {
@@ -567,8 +574,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# --- Baseline model: Random Forest in a sklearn Pipeline ---\n",
     "#\n",
@@ -587,9 +596,11 @@
     "#   - sklearn default, good balance speed/performance for a baseline\n",
     "#   - We'll tune this later if needed (YAGNI — don't optimize prematurely)\n",
     "\n",
-    "pipe = Pipeline([\n",
-    "    (\"model\", RandomForestClassifier(n_estimators=100, random_state=RANDOM_STATE)),\n",
-    "])\n",
+    "pipe = Pipeline(\n",
+    "    [\n",
+    "        (\"model\", RandomForestClassifier(n_estimators=100, random_state=RANDOM_STATE)),\n",
+    "    ]\n",
+    ")\n",
     "\n",
     "# --- Cross-validation (Stratified K-Fold, k=5) ---\n",
     "# WHY Stratified K-Fold instead of a single train/val split?\n",
@@ -609,29 +620,17 @@
     "print(\"=\" * 60)\n",
     "print(f\"\\nCross-validation scores: {cv_scores}\")\n",
     "print(f\"Mean CV Accuracy: {cv_scores.mean():.4f} (+/- {cv_scores.std():.4f})\")\n",
-    "print(f\"\\nThis is our baseline score to beat.\")\n",
+    "print(\"\\nThis is our baseline score to beat.\")\n",
     "\n",
     "# Train on full train set for validation metrics and feature importance\n",
     "pipe.fit(X_train, y_train)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Prepare features and target\n",
-    "# TODO: Select your feature columns\n",
-    "# feature_cols = [\"col1\", \"col2\", \"col3\"]\n",
-    "# X = train_df[feature_cols]\n",
-    "# y = train_df[TARGET_COL]\n",
-    "\n",
-    "# Train/validation split\n",
-    "# X_train, X_val, y_train, y_val = train_test_split(\n",
-    "#     X, y, test_size=TEST_SIZE, random_state=RANDOM_STATE\n",
-    "# )\n",
-    "# print(f\"Train: {X_train.shape}, Validation: {X_val.shape}\")"
+    "## 8. Evaluation"
    ]
   },
   {
@@ -683,8 +682,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# --- Feature Importance ---\n",
     "# WHY look at feature importance?\n",
@@ -694,10 +695,12 @@
     "#   - Random Forest importance = how much each feature reduces impurity (Gini)\n",
     "\n",
     "model = pipe.named_steps[\"model\"]\n",
-    "importance_df = pd.DataFrame({\n",
-    "    \"feature\": feature_cols,\n",
-    "    \"importance\": model.feature_importances_,\n",
-    "}).sort_values(\"importance\", ascending=False)\n",
+    "importance_df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"feature\": feature_cols,\n",
+    "        \"importance\": model.feature_importances_,\n",
+    "    }\n",
+    ").sort_values(\"importance\", ascending=False)\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(10, 6))\n",
     "sns.barplot(data=importance_df, x=\"importance\", y=\"feature\", ax=ax, palette=\"viridis\")\n",
@@ -711,28 +714,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Predictions on validation set\n",
-    "# y_pred = model.predict(X_val)\n",
-    "\n",
-    "# For classification:\n",
-    "# print(f\"Accuracy: {accuracy_score(y_val, y_pred):.4f}\")\n",
-    "# print(f\"\\nClassification Report:\")\n",
-    "# print(classification_report(y_val, y_pred))\n",
-    "\n",
-    "# Confusion matrix\n",
-    "# fig, ax = plt.subplots(figsize=(8, 6))\n",
-    "# cm = confusion_matrix(y_val, y_pred)\n",
-    "# sns.heatmap(cm, annot=True, fmt=\"d\", cmap=\"Blues\", ax=ax)\n",
-    "# ax.set_title(\"Confusion Matrix\")\n",
-    "# ax.set_ylabel(\"Actual\")\n",
-    "# ax.set_xlabel(\"Predicted\")\n",
-    "# plt.tight_layout()\n",
-    "# plt.show()"
+    "## 9. Submission"
    ]
   },
   {
@@ -824,37 +809,6 @@
     "    print(\"\\nAll checks passed — ready to submit to Kaggle!\")\n",
     "else:\n",
     "    print(\"\\nSome checks FAILED — fix before submitting.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 9. Submission"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Generate predictions on test set\n",
-    "# TODO: Apply same preprocessing to test_df\n",
-    "# X_test = test_df[feature_cols]\n",
-    "# test_predictions = model.predict(X_test)\n",
-    "\n",
-    "# Create submission file\n",
-    "# TODO: Adapt columns to match competition requirements\n",
-    "# submission = pd.DataFrame({\n",
-    "#     \"Id\": test_df[\"Id\"],\n",
-    "#     TARGET_COL: test_predictions\n",
-    "# })\n",
-    "\n",
-    "# submission.to_csv(SUBMISSIONS_DIR / \"submission.csv\", index=False)\n",
-    "# print(f\"Submission saved to {SUBMISSIONS_DIR / 'submission.csv'}\")\n",
-    "# print(f\"Shape: {submission.shape}\")\n",
-    "# submission.head()"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Fix critical bug: two code cells (Pipeline/CV and Feature Importance) were incorrectly saved as markdown cells, causing `NameError: name 'pipe' is not defined` when running the notebook. Also clean up leftover template cells and restore proper section headers.

## Root cause

When editing notebook cells, some code cells were converted to markdown type. This meant the Pipeline model was never created, causing all downstream cells (evaluation, submission) to fail.

## Changes

- [x] Convert Pipeline/CV cell from markdown → code (was never executing)
- [x] Convert Feature Importance cell from markdown → code
- [x] Remove 3 leftover template cells (old commented placeholders from initial template)
- [x] Restore proper section headers: ## 6. Feature Engineering, ## 7. Modeling, ## 8. Evaluation, ## 9. Submission
- [x] Fix f-string lint error

## Type of Change

- [x] Bug fix (`fix`)

## Checklist

- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] `make lint` passes
- [x] Notebook outputs are stripped (nbstripout)
- [x] Tests pass (15/15)
- [x] No raw data or model files committed