### PR TITLE
chore(docs): log first Kaggle submission score (LB 0.74880)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ make notebook
 
 ## Project Structure
 
-```
+```text
 .
 ├── data/
 │   ├── raw/              # Original competition data (gitignored)
@@ -67,7 +67,7 @@ make notebook
 
 | # | Model | CV Score | LB Score | Features |
 | --- | --- | --- | --- | --- |
-| 1 | Random Forest (100 trees) | ~0.80 | TBD | Pclass, Sex, Age, SibSp, Parch, Fare, Embarked, HasCabin, FamilySize, IsAlone, Title |
+| 1 | Random Forest (100 trees) | ~0.80 | 0.74880 | Pclass, Sex, Age, SibSp, Parch, Fare, Embarked, HasCabin, FamilySize, IsAlone, Title |
 
 ## Available Commands
 

--- a/outputs/submissions/log.md
+++ b/outputs/submissions/log.md
@@ -4,4 +4,4 @@ Track all Kaggle submissions for this competition.
 
 | # | Date | CV Score | LB Score | Model | Features | File | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | 2026-03-25 | ~0.80 | TBD | RandomForest (100 trees) | Pclass, Sex, Age, SibSp, Parch, Fare, Embarked, HasCabin, FamilySize, IsAlone, Title | `submission_001_rf_baseline.csv` | Baseline — no tuning, default hyperparameters |
+| 1 | 2026-03-25 | ~0.80 | 0.74880 | RandomForest (100 trees) | Pclass, Sex, Age, SibSp, Parch, Fare, Embarked, HasCabin, FamilySize, IsAlone, Title | `submission_001_rf_baseline.csv` | Baseline — no tuning. CV optimistic vs LB (overfitting). Room for improvement. |


### PR DESCRIPTION
## Summary

Log the actual Kaggle public leaderboard score from our first baseline submission.

## Results

| Metric | Value |
| --- | --- |
| CV Score (local) | ~0.80 |
| LB Score (Kaggle) | **0.74880** |
| Gap | ~0.05 (CV optimistic, slight overfitting) |

## Changes

- [x] Update `outputs/submissions/log.md` with LB score 0.74880
- [x] Update `README.md` Current Results with real score

## Type of Change

- [x] Documentation (`docs`)

## Checklist

- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] Submission score logged in `outputs/submissions/log.md`
- [x] No raw data or model files committed